### PR TITLE
chore: ignore *.org and *.ref from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,5 @@ dist
 
 .idea
 reports
+*.orig
+*.rej


### PR DESCRIPTION
echo -e "\n*.orig\n*.rej\n" >> .gitignore